### PR TITLE
2020.01.09/replace shows with tour dates

### DIFF
--- a/web/woatw-20191224/components/fix-for-locale-display-bug-in-theme/shows.js
+++ b/web/woatw-20191224/components/fix-for-locale-display-bug-in-theme/shows.js
@@ -8,17 +8,11 @@ import LandingSectionTitle from "./landing-section-title"
 import ShowItem from "./show-item"
 
 const ShowsV2 = ({ shows = [], locale = "en-US" }) => {
-  // Use text label from YAML user config
-  let sectionTitle = "Shows"
   const { textLabels } = useSiteMetadata()
-  if (typeof textLabels.section_shows_title !== "undefined") {
-    if (textLabels.section_shows_title.length) {
-      sectionTitle = textLabels.section_shows_title
-    }
-  }
+  const sectionTitle = textLabels.section_shows_title || "Tour Dates"
 
   return (
-    <section id="shows" sx={{ variant: "layout.landingSection" }}>
+    <section id="tour-dates" sx={{ variant: "layout.landingSection" }}>
       <LandingSectionTitle>{sectionTitle}</LandingSectionTitle>
       <ol
         sx={{

--- a/web/woatw-20191224/content/artist-landing-page.mdx
+++ b/web/woatw-20191224/content/artist-landing-page.mdx
@@ -23,6 +23,10 @@ import Subscribe from '../src/components/mailchimp/subscribe.js'
 <ReleasesV2 releases={props.releases} locale="en-US" />
 
 <ShowsV2 shows={props.shows} locale="en-US" />
+<div id="special-announcement" className="text-center">
+  <h3>Silver Bullet Summer Tour announcement coming soon!</h3>
+  <p/>
+</div>
 
 <div id="videos">
   <h2>Videos</h2>

--- a/web/woatw-20191224/content/shows.yml
+++ b/web/woatw-20191224/content/shows.yml
@@ -1,10 +1,10 @@
-- name: WOATW (also feat. Rucker, Designer Disguise, and Benicio Bryant)
+- name: Wyatt Olney & The Wreckage (feat. Rucker)
   date: "2020-01-24"
   location: Tony V's Garage Saloon & Eatery, 1716 Hewitt Ave, Everett, WA, 98201
   # info_url and map_url are optional
   info_url: https://www.facebook.com/events/529398251189464/
   map_url: https://www.google.com/maps/place/Tony+V's+Garage+Saloon+%26+Eatery/@47.9791285,-122.2084362,17z/data=!3m1!4b1!4m5!3m4!1s0x549aaa99ebbc5a0d:0xc25a453ef324ac00!8m2!3d47.9791249!4d-122.2062476
-- name: WOATW (also feat. Woodshed, The Requisite, and End of May)
+- name: Wyatt Olney & The Wreckage (feat. Woodshed & The Requisite)
   date: "2020-02-22"
   location: Aurora Borealis, 16708 Aurora Ave N, Shoreline, WA, 98133
   # info_url and map_url are optional

--- a/web/woatw-20191224/src/gatsby-theme-musician/config/navigation.yml
+++ b/web/woatw-20191224/src/gatsby-theme-musician/config/navigation.yml
@@ -1,8 +1,8 @@
 navigation:
   - text: Releases
     url: "#releases"
-  - text: Shows
-    url: "#shows"
+  - text: Tour Dates
+    url: "#tour-dates"
   - text: Videos
     url: "#videos"
   - text: Contact

--- a/web/woatw-20191224/src/gatsby-theme-musician/config/text_labels.yml
+++ b/web/woatw-20191224/src/gatsby-theme-musician/config/text_labels.yml
@@ -1,3 +1,3 @@
 section_releases_title: Releases
 
-section_shows_title: Shows
+section_shows_title: Tour Dates


### PR DESCRIPTION
Let's get this ready for our summer tour. Instead of shows, we are going to use tour dates instead.

Before:
<img width="1902" alt="Screen Shot 2020-01-09 at 12 58 25 PM" src="https://user-images.githubusercontent.com/4030490/72104261-e5a34600-32df-11ea-9edc-7a94b6fd0373.png">

After:
<img width="1902" alt="Screen Shot 2020-01-09 at 12 58 04 PM" src="https://user-images.githubusercontent.com/4030490/72104273-ed62ea80-32df-11ea-9cf5-86caaba71e69.png">
