### PR TITLE
2020.01.14/bug fix mobile portrait mode navigation

### DIFF
--- a/web/woatw-20191224/content/artist-landing-page.mdx
+++ b/web/woatw-20191224/content/artist-landing-page.mdx
@@ -22,12 +22,17 @@ import LandingSectionTitle from '../components/fix-for-locale-display-bug-in-the
 -->
 
 <ShowsV2 shows={props.shows} locale="en-US" />
+
 <div id="special-announcement" className="text-center">
   <h3>Silver Bullet Summer Tour announcement coming soon!</h3>
-  <p/>
 </div>
 
 <ReleasesV2 releases={props.releases} locale="en-US" />
+
+<!-- Videos -->
+<div id="videos" className="text-center">
+  <LandingSectionTitle>Videos</LandingSectionTitle>
+</div>
 
 <!-- Silver Bullet -->
 <Youtube url="https://www.youtube.com/watch?v=_nNYBsqWMV0" />

--- a/web/woatw-20191224/content/artist-landing-page.mdx
+++ b/web/woatw-20191224/content/artist-landing-page.mdx
@@ -29,9 +29,9 @@ import LandingSectionTitle from '../components/fix-for-locale-display-bug-in-the
 
 <ReleasesV2 releases={props.releases} locale="en-US" />
 
-<!-- Videos -->
+<!-- Music Videos -->
 <div id="videos" className="text-center">
-  <LandingSectionTitle>Videos</LandingSectionTitle>
+  <LandingSectionTitle>Music Videos</LandingSectionTitle>
 </div>
 
 <!-- Silver Bullet -->

--- a/web/woatw-20191224/content/artist-landing-page.mdx
+++ b/web/woatw-20191224/content/artist-landing-page.mdx
@@ -21,17 +21,13 @@ import LandingSectionTitle from '../components/fix-for-locale-display-bug-in-the
 </p>
 -->
 
-<ReleasesV2 releases={props.releases} locale="en-US" />
-
 <ShowsV2 shows={props.shows} locale="en-US" />
 <div id="special-announcement" className="text-center">
   <h3>Silver Bullet Summer Tour announcement coming soon!</h3>
   <p/>
 </div>
 
-<div id="videos">
-  <LandingSectionTitle>{`Videos`}</LandingSectionTitle>
-</div>
+<ReleasesV2 releases={props.releases} locale="en-US" />
 
 <!-- Silver Bullet -->
 <Youtube url="https://www.youtube.com/watch?v=_nNYBsqWMV0" />
@@ -48,6 +44,7 @@ import LandingSectionTitle from '../components/fix-for-locale-display-bug-in-the
 <!-- Embed Spotify and Soundcloud tracks -->
 <!-- https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC -->
 
+<!-- Booking Info -->
 <div id="booking-info" className="text-center">
   <LandingSectionTitle>{`Booking Info`}</LandingSectionTitle>
 

--- a/web/woatw-20191224/content/artist-landing-page.mdx
+++ b/web/woatw-20191224/content/artist-landing-page.mdx
@@ -49,8 +49,8 @@ import LandingSectionTitle from '../components/fix-for-locale-display-bug-in-the
 <!-- Embed Spotify and Soundcloud tracks -->
 <!-- https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC -->
 
-<!-- Booking Info -->
-<div id="booking-info" className="text-center">
+<!-- Booking -->
+<div id="booking" className="text-center">
   <LandingSectionTitle>{`Booking Info`}</LandingSectionTitle>
 
   <figure>

--- a/web/woatw-20191224/src/gatsby-theme-musician/config/navigation.yml
+++ b/web/woatw-20191224/src/gatsby-theme-musician/config/navigation.yml
@@ -4,7 +4,7 @@ navigation:
   - text: Tour Dates
     url: "#tour-dates"
   - text: Booking
-    url: "#booking-info"
+    url: "#booking"
   # TODO: Bio will be added in an upcoming feature
   # - text: Bio
   #   url: "#bio"

--- a/web/woatw-20191224/src/gatsby-theme-musician/config/navigation.yml
+++ b/web/woatw-20191224/src/gatsby-theme-musician/config/navigation.yml
@@ -3,7 +3,8 @@ navigation:
     url: "#releases"
   - text: Tour Dates
     url: "#tour-dates"
-  - text: Videos
-    url: "#videos"
-  - text: Booking Info
+  - text: Booking
     url: "#booking-info"
+  # TODO: Bio will be added in an upcoming feature
+  # - text: Bio
+  #   url: "#bio"


### PR DESCRIPTION
This starter theme begins to break down when there is a longer list of navigation items.

For example, here is how the site appeared on a mobile phone:
![82964585_600990460698400_2593460102690242560_n](https://user-images.githubusercontent.com/4030490/72412531-64eeaa80-3722-11ea-8c18-6880e4325457.png)

This PR ~~fixes~~ hacks around that bug by simplifying the navigation items:
![IMG_B22D5D4EF933-1](https://user-images.githubusercontent.com/4030490/72412556-79cb3e00-3722-11ea-9193-ac3b9dc82ed6.jpeg)

The real fix would be to address this in the theme. Given that future plans include forking and creating a heavily modified version of the existing starter theme, doing a hack will be OK for now. Not ideal, but it works.