### PR TITLE
2020.01.16/enhance banner image for mobile portrait display

### DIFF
--- a/web/woatw-20191224/gatsby-config.js
+++ b/web/woatw-20191224/gatsby-config.js
@@ -67,5 +67,16 @@ module.exports = {
         endpoint: 'https://woatw.us11.list-manage.com/subscribe/post?u=6ebf45cada6d638457bc51a30&amp;id=64b10a0a10',
       },
     },
+
+    // Let's process our own images with Gatsby instead of relying upon the starter theme
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `images`,
+        path: `${__dirname}/content/images`,
+      },
+    },
+    `gatsby-transformer-sharp`,
+    `gatsby-plugin-sharp`,
   ]
 };

--- a/web/woatw-20191224/package-lock.json
+++ b/web/woatw-20191224/package-lock.json
@@ -8162,15 +8162,6 @@
           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
           "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
         },
-        "read-chunk": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-3.2.0.tgz",
-          "integrity": "sha512-CEjy9LCzhmD7nUpJ1oVOE6s/hBkejlcJEgLQHVnQznOSilOPb+kpKktlLfFDK3/WP43+F80xkUTM2VOkYoSYvQ==",
-          "requires": {
-            "pify": "^4.0.1",
-            "with-open-file": "^0.1.6"
-          }
-        },
         "url-parse-lax": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -14395,6 +14386,15 @@
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "requires": {
         "mute-stream": "~0.0.4"
+      }
+    },
+    "read-chunk": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-3.2.0.tgz",
+      "integrity": "sha512-CEjy9LCzhmD7nUpJ1oVOE6s/hBkejlcJEgLQHVnQznOSilOPb+kpKktlLfFDK3/WP43+F80xkUTM2VOkYoSYvQ==",
+      "requires": {
+        "pify": "^4.0.1",
+        "with-open-file": "^0.1.6"
       }
     },
     "read-pkg": {

--- a/web/woatw-20191224/package.json
+++ b/web/woatw-20191224/package.json
@@ -21,10 +21,13 @@
   },
   "dependencies": {
     "gatsby": "^2.13.28",
+    "gatsby-image": "^2.2.38",
     "gatsby-plugin-gtag": "^1.0.12",
     "gatsby-plugin-mailchimp": "^5.1.2",
     "gatsby-plugin-manifest": "^2.2.37",
+    "gatsby-plugin-sharp": "^2.3.13",
     "gatsby-theme-musician": "^1.0.5",
+    "gatsby-transformer-sharp": "^2.3.12",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/web/woatw-20191224/package.json
+++ b/web/woatw-20191224/package.json
@@ -26,6 +26,7 @@
     "gatsby-plugin-mailchimp": "^5.1.2",
     "gatsby-plugin-manifest": "^2.2.37",
     "gatsby-plugin-sharp": "^2.3.13",
+    "gatsby-source-filesystem": "^2.1.46",
     "gatsby-theme-musician": "^1.0.5",
     "gatsby-transformer-sharp": "^2.3.12",
     "react": "^16.8.6",

--- a/web/woatw-20191224/src/components/banner.js
+++ b/web/woatw-20191224/src/components/banner.js
@@ -8,14 +8,16 @@ import useSiteMetadata from "./use-site-metadata"
 import HeroImage from "./hero-image"
 import Social from "./social"
 
-let additionalStyles = {}
+let additionalStyles = {
+  minHeight: '200px',
+}
 let bgOverlayStyles = {}
 
 const BannerV2 = ({ children, bgOverlay, color }) => {
   const { bannerImg } = useSiteMetadata()
 
   if (color) {
-    additionalStyles["color"] = "color"
+    additionalStyles["color"] = color
   }
 
   if (bgOverlay) {
@@ -43,10 +45,12 @@ const BannerV2 = ({ children, bgOverlay, color }) => {
         <HeroImage
           className="GtmBanner__hero-wrapper"
           fluid={bannerImg.fluid}
-          sx={{ flexGrow: 1 }}
+          sx={{ flexGrow: 0, display: 'contents' }}
         >
           <Container
-            className="GtmBanner__content-wrapper"
+            className="GtmBanner__content-wrapper abc"
+            sx={{ flexGrow: 0 }}
+            style={{ paddingTop: 40 }}
             >
             {children || bannerContentElement}
           </Container>

--- a/web/woatw-20191224/src/components/hero-image.js
+++ b/web/woatw-20191224/src/components/hero-image.js
@@ -1,19 +1,19 @@
 /** @jsx jsx */
 // eslint-disable-next-line no-unused-vars
-import React from "react"
-import Img from "gatsby-image"
-import { Styled, jsx } from "theme-ui"
+import React from 'react';
+import Img from 'gatsby-image';
+import { Styled, jsx } from 'theme-ui';
 
 const HeroImage = props => {
   return (
-    <Styled.div {...props} sx={{ variant: "components.heroImg.parent" }}>
+    <Styled.div {...props} sx={{ variant: 'components.heroImg.parent' }}>
       <Img
-        sx={{ variant: "components.heroImg.gatsbyImg" }}
+        sx={{ variant: 'components.heroImg.gatsbyImg' }}
         fluid={props.fluid}
       />
-      <div sx={{ variant: "components.heroImg.content" }}>{props.children}</div>
+      <div sx={{ variant: 'components.heroImg.content' }}>{props.children}</div>
     </Styled.div>
-  )
-}
+  );
+};
 
-export default HeroImage
+export default HeroImage;

--- a/web/woatw-20191224/src/components/shows.js
+++ b/web/woatw-20191224/src/components/shows.js
@@ -12,7 +12,7 @@ const ShowsV2 = ({ shows = [], locale = "en-US" }) => {
   const sectionTitle = textLabels.section_shows_title || "Tour Dates"
 
   return (
-    <section id="tour-dates" sx={{ variant: "layout.landingSection" }}>
+    <section id="tour-dates" sx={{ variant: "layout.landingSection", paddingTop: 0 }}>
       <LandingSectionTitle>{sectionTitle}</LandingSectionTitle>
       <ol
         sx={{


### PR DESCRIPTION
This PR fixes an issue where the artist-banner artwork was cut off when viewing in portrait mode on a mobile device:

Before:
![Jan-16-2020 17-03-55 before](https://user-images.githubusercontent.com/4030490/72587262-7b733e00-38a9-11ea-8e94-f8ff07583025.gif)

After:
![Jan-16-2020 21-37-41 after](https://user-images.githubusercontent.com/4030490/72587266-7e6e2e80-38a9-11ea-9360-440f71f076c6.gif)
