### PR TITLE
Commented out last night's show

### DIFF
--- a/web/woatw-20191224/content/shows.yml
+++ b/web/woatw-20191224/content/shows.yml
@@ -1,9 +1,9 @@
-- name: Wyatt Olney & The Wreckage (feat. Rucker)
-  date: "2020-01-24"
-  location: Tony V's Garage Saloon & Eatery, 1716 Hewitt Ave, Everett, WA, 98201
-  # info_url and map_url are optional
-  info_url: https://www.facebook.com/events/529398251189464/
-  map_url: https://www.google.com/maps/place/Tony+V's+Garage+Saloon+%26+Eatery/@47.9791285,-122.2084362,17z/data=!3m1!4b1!4m5!3m4!1s0x549aaa99ebbc5a0d:0xc25a453ef324ac00!8m2!3d47.9791249!4d-122.2062476
+# - name: Wyatt Olney & The Wreckage (feat. Rucker)
+#   date: "2020-01-24"
+#   location: Tony V's Garage Saloon & Eatery, 1716 Hewitt Ave, Everett, WA, 98201
+#   # info_url and map_url are optional
+#   info_url: https://www.facebook.com/events/529398251189464/
+#   map_url: https://www.google.com/maps/place/Tony+V's+Garage+Saloon+%26+Eatery/@47.9791285,-122.2084362,17z/data=!3m1!4b1!4m5!3m4!1s0x549aaa99ebbc5a0d:0xc25a453ef324ac00!8m2!3d47.9791249!4d-122.2062476
 - name: Wyatt Olney & The Wreckage (feat. Woodshed & The Requisite)
   date: "2020-02-22"
   location: Aurora Borealis, 16708 Aurora Ave N, Shoreline, WA, 98133


### PR DESCRIPTION
We will return to the venue later in the year; let's retain the data by commenting it out for now.
![01](https://user-images.githubusercontent.com/4030490/73125481-087a5f00-3f5c-11ea-86ae-71c6929fa052.jpeg)
![02](https://user-images.githubusercontent.com/4030490/73125482-087a5f00-3f5c-11ea-98db-97c32a3ba372.jpeg)
![03](https://user-images.githubusercontent.com/4030490/73125483-087a5f00-3f5c-11ea-8174-0caa505a010c.jpeg)
